### PR TITLE
SSCS-5166 - trust all ssl certs fix

### DIFF
--- a/src/integrationTest/java/uk/gov/hmcts/reform/sscs/servicebus/TopicJmsTest.java
+++ b/src/integrationTest/java/uk/gov/hmcts/reform/sscs/servicebus/TopicJmsTest.java
@@ -30,7 +30,9 @@ public class TopicJmsTest {
         "clientId", "guest", "guest",
         "amqp://localhost:8899?amqp.idleTimeout=120000"
             + "&amqp.saslMechanisms=PLAIN&transport.trustAll=true"
-            + "&transport.verifyHost=false");
+            + "&transport.verifyHost=false",
+        config.jmsSslContext(true)
+        );
     private final JmsTemplate jmsTemplate = config.jmsTemplate(connectionFactory);
 
 

--- a/src/main/resources/application.yaml
+++ b/src/main/resources/application.yaml
@@ -11,11 +11,13 @@ spring:
     name: ccd callback orchestrator
 
 amqp:
-  host: localhost
-  username: guest
-  password: guest
-  topic: test.topic
-  subscription: test.queue
+  host: ${AMQP_HOST:localhost}
+  username: ${AMQP_USERNAME:guest}
+  password: ${AMQP_PASSWORD:guest}
+  topic: ${TOPIC_NAME:test.topic}
+  subscription: ${SUBSCRIPTION_NAME:test.queue}
+  # DO NOT SET THIS 'true' IN PRODUCTION!
+  trustAllCerts: ${TRUST_ALL_CERTS:true}
 
 idam:
   url: ${IDAM_URL:http://localhost:4501}


### PR DESCRIPTION
Fix for errors found by @keefmarshall 

We do not want to trust all ssl certs in production.
Azure service bus, will, by default have correctly signed certificates to use.

`trustAllCerts` = `true` is used only locally when using qpid broker and creating a self signed ssl cert.