### PR TITLE
SSCS-5424 - CCD displays errors on callbacks

### DIFF
--- a/config/owasp/suppressions.xml
+++ b/config/owasp/suppressions.xml
@@ -18,4 +18,11 @@
     <notes><![CDATA[ I can't upgrade qpid-jms-client-0.40.0.ja so I'm suppressing the vulnerability... ]]></notes>
     <cve>CVE-2016-4432</cve>
   </suppress>
+  <suppress>
+    <notes><![CDATA[
+   file name: spring-security-crypto-5.1.3.RELEASE.jar
+   ]]></notes>
+    <gav regex="true">^org\.springframework\.security:spring-.*:.*$</gav>
+    <cve>CVE-2018-1258</cve>
+  </suppress>
 </suppressions>

--- a/src/functionalTest/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackOrchestratorControllerTest.java
+++ b/src/functionalTest/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackOrchestratorControllerTest.java
@@ -11,6 +11,7 @@ import org.springframework.cloud.openfeign.EnableFeignClients;
 import org.springframework.http.HttpEntity;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.test.context.ContextConfiguration;
 import org.springframework.test.context.junit4.SpringRunner;
@@ -62,6 +63,6 @@ public class CcdCallbackOrchestratorControllerTest {
         HttpEntity<String> request = new HttpEntity<String>("{'json': true}", headers);
         ResponseEntity<String> response = restTemplate.exchange("/send", HttpMethod.POST, request, String.class);
 
-        assertEquals(201, response.getStatusCodeValue());
+        assertEquals(HttpStatus.OK.value(), response.getStatusCodeValue());
     }
 }

--- a/src/main/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackOrchestratorController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackOrchestratorController.java
@@ -31,6 +31,6 @@ public class CcdCallbackOrchestratorController {
         @RequestBody String body) {
         authorisationService.authorise(serviceAuthHeader);
         topicPublisher.sendMessage(body);
-        return new ResponseEntity(HttpStatus.CREATED);
+        return new ResponseEntity(HttpStatus.OK);
     }
 }


### PR DESCRIPTION
# SSCS-5424 - CCD displaying error on Service Bus callbacks

When testing locally, CCD displays an error as soon as a callback is triggered to the Service Bus. 

The Service Bus then proceeds to process the callback as normal. 

We need to investigate why this error is immediately displayed in CCD. 

![image](https://user-images.githubusercontent.com/369407/55632241-c821d880-57b1-11e9-94f5-30dceebf6db3.png)

-------

The error was happening due to this service returning a 201. It would seem ccd cannot handle this return value. However it can handle a 200 status code.
