### PR TITLE
CCD Callback message after an event is triggered

### DIFF
--- a/src/main/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackOrchestratorController.java
+++ b/src/main/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackOrchestratorController.java
@@ -26,11 +26,11 @@ public class CcdCallbackOrchestratorController {
     }
 
     @RequestMapping(value = "/send", produces = APPLICATION_JSON_VALUE, method = RequestMethod.POST)
-    public ResponseEntity send(
+    public ResponseEntity<String> send(
         @RequestHeader(AuthorisationService.SERVICE_AUTHORISATION_HEADER) String serviceAuthHeader,
         @RequestBody String body) {
         authorisationService.authorise(serviceAuthHeader);
         topicPublisher.sendMessage(body);
-        return new ResponseEntity(HttpStatus.OK);
+        return new ResponseEntity<>("{}", HttpStatus.OK);
     }
 }

--- a/src/test/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackOrchestratorControllerTest.java
+++ b/src/test/java/uk/gov/hmcts/reform/sscs/controllers/CcdCallbackOrchestratorControllerTest.java
@@ -3,9 +3,11 @@ package uk.gov.hmcts.reform.sscs.controllers;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
+import org.springframework.http.ResponseEntity;
 import uk.gov.hmcts.reform.sscs.service.AuthorisationService;
 import uk.gov.hmcts.reform.sscs.servicebus.TopicPublisher;
 
+import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.MockitoAnnotations.initMocks;
@@ -30,7 +32,9 @@ public class CcdCallbackOrchestratorControllerTest {
 
     @Test
     public void shouldCreateAndSendNotificationForSscsCaseData() {
-        controller.send("", MESSAGE);
+        ResponseEntity<String> responseEntity = controller.send("", MESSAGE);
         verify(topicPublisher).sendMessage(eq(MESSAGE));
+        assertEquals(200, responseEntity.getStatusCode().value());
+        assertEquals("{}", responseEntity.getBody());
     }
 }


### PR DESCRIPTION
Fix CCD Callback so that an error message does not trigger on a CCD event.
