### PR TITLE
SSCS-10166-in build gradle sscs common version is updated

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -291,7 +291,7 @@ dependencies {
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
   testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
 
-  testCompile group: 'com.github.hmcts', name: 'sscs-common', version: '4.6.45-RC-SSCS-10166'
+  testCompile group: 'com.github.hmcts', name: 'sscs-common', version: '4.6.45'
   testCompile 'com.github.hmcts:fortify-client:1.2.1:all'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'

--- a/build.gradle
+++ b/build.gradle
@@ -290,8 +290,8 @@ dependencies {
   testImplementation group: 'org.junit.jupiter', name: 'junit-jupiter-api', version: versions.junit
   testCompile group: 'org.junit.jupiter', name: 'junit-jupiter-params', version: versions.junit
   testRuntimeOnly group: 'org.junit.jupiter', name: 'junit-jupiter-engine', version: versions.junit
-  
-  testCompile group: 'com.github.hmcts', name: 'sscs-common', version: '4.6.38'
+
+  testCompile group: 'com.github.hmcts', name: 'sscs-common', version: '4.6.45-RC-SSCS-10166'
   testCompile 'com.github.hmcts:fortify-client:1.2.1:all'
 
   testCompile group: 'org.springframework.boot', name: 'spring-boot-starter-test'


### PR DESCRIPTION
Please remove this line and everything above and fill the following sections:


### JIRA link (if applicable) ###
https://tools.hmcts.net/jira/browse/SSCS-10166



### Change description ###
poi and opencvs versions are updated in sscs-common and sscs-pdf-email-common as the security vulnerabilities they have are preventing feature developments


**Does this PR introduce a breaking change?** (check one with "x")

```
[X ] Yes
[ ] No
```
